### PR TITLE
Bump version (v0.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## [v0.0.2](https://github.com/NubeIO/module-core-rql/tree/v0.0.2) (2023-10-09)
+
+- Use internal token in rubixoscli
+- Call ROS directly instead of proxying through BIOS
+- Upgrade ROS version and rubixoscli
+- Write DB in the appropriate location
+- Don't display it on frontend for creating networks
+
 ## [v0.0.1](https://github.com/NubeIO/module-core-rql/tree/v0.0.1) (2023-10-08)
 
 - Initial first release


### PR DESCRIPTION
### Summary

- Use internal token in rubixoscli
- Call ROS directly instead of proxying through BIOS
- Upgrade ROS version and rubixoscli
- Write DB in the appropriate location
- Don't display it on frontend for creating networks